### PR TITLE
support for grid tilt

### DIFF
--- a/mouse.lua
+++ b/mouse.lua
@@ -639,19 +639,19 @@ function grid_tilt(_grid_id, _x, _y)
   end
 
   local median = 130
-  local xd = 0
-  local yd = 0
+  local o_margin = 10
 
-  if (median - _x) > 10 then
-    xd = 1
-  elseif (median - _x) < -10 then
-    xd = -1
+  local xd = (median - _x)
+  local yd = (median - _y)
+  if math.abs(xd) < o_margin then
+    xd = 0
+  else
+    xd = math.floor(xd / 10)
   end
-
-  if (median - _y) > 10 then
-    yd = 1
-  elseif (median - _y) < -10 then
-    yd = -1
+  if math.abs(yd) < o_margin then
+    yd = 0
+  else
+    yd = math.floor(yd / 10)
   end
 
   if xd ~= 0 or yd ~= 0 then

--- a/mouse.lua
+++ b/mouse.lua
@@ -245,6 +245,8 @@ end
 local function setup_grid()
   g = grid.connect()
   g.key = grid_key
+  g.tilt = grid_tilt
+  g:tilt_enable(0, 1)
   grid_redraw()
 end
 
@@ -626,6 +628,39 @@ function grid_key(_x, _y, z)
   
   redraw()
   grid_redraw()
+end
+
+local last_tilt_ts = nil
+
+function grid_tilt(_grid_id, _x, _y)
+  local now = os.clock()
+  if last_tilt_ts ~= nil and (now - last_tilt_ts) < 0.005 then
+    return
+  end
+
+  local median = 130
+  local xd = 0
+  local yd = 0
+
+  if (median - _x) > 10 then
+    xd = 1
+  elseif (median - _x) < -10 then
+    xd = -1
+  end
+
+  if (median - _y) > 10 then
+    yd = 1
+  elseif (median - _y) < -10 then
+    yd = -1
+  end
+
+  if xd ~= 0 or yd ~= 0 then
+    x = util.clamp(x + xd, 1, #scale)
+    y = util.clamp(y + yd, 1, #scale)
+    redraw()
+  end
+
+  last_tilt_ts = os.clock()
 end
 
 function grid_redraw()


### PR DESCRIPTION
older grid models have a tilt sensor.

norns' grid API now [support reading the tilt values](https://github.com/monome/norns/pull/1477).
`mouse` seemed like the perfect script to control via tilting, this is what this PR provides, and it's indeed quite satisfying!

~~it could be improved further by accelerating the movements of the "cursor" depending on the amount of tilt but it's already quite playful as is.~~ edit: done.